### PR TITLE
feat: Implementação API Gateway com Autorização Cognito

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -54,3 +54,45 @@ resource "aws_iam_role_policy_attachment" "lambda_dynamodb_policy_attachment" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = aws_iam_policy.lambda_dynamodb_policy.arn
 }
+
+# IAM Policy for API Gateway to access CloudWatch Logs
+resource "aws_iam_role" "api_gateway_role" {
+  name = "api-gateway-cloudwatch-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "apigateway.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "api_gateway_cloudwatch_policy" {
+  name = "api-gateway-cloudwatch-policy"
+  role = aws_iam_role.api_gateway_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:PutLogEvents",
+          "logs:GetLogEvents",
+          "logs:FilterLogEvents"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,7 +100,7 @@ module "cognito" {
   source         = "./modules/cognito"
   user_pool_name = "user-pool-hello-api-prod"
   client_name    = "hello-api-client"
-  domain_prefix  = "hello-terraform-api-auth-v2-unique123"
+  domain_prefix  = "hello-terraform-api-auth-v2"
 }
 
 module "api_gateway" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,5 +100,16 @@ module "cognito" {
   source         = "./modules/cognito"
   user_pool_name = "user-pool-hello-api-prod"
   client_name    = "hello-api-client"
-  domain_prefix  = "hello-terraform-api-auth-v2"
+  domain_prefix  = "hello-terraform-api-auth-v2-unique123"
+}
+
+module "api_gateway" {
+  source = "./modules/api_gateway"
+
+  api_name                        = "hello-terraform-api"
+  environment                     = var.environment
+  cognito_user_pool_arn          = module.cognito.user_pool_arn
+  lambda_invoke_arn              = module.hello_terraform.invoke_arn
+  lambda_function_name           = module.hello_terraform.function_name
+  api_gateway_cloudwatch_role_arn = aws_iam_role.api_gateway_role.arn  
 }

--- a/terraform/modules/api_gateway/main.tf
+++ b/terraform/modules/api_gateway/main.tf
@@ -1,0 +1,144 @@
+resource "aws_api_gateway_rest_api" "this" {
+  name        = var.api_name
+  description = "API Gateway para Hello Terraform com autenticação Cognito"
+}
+
+resource "aws_api_gateway_resource" "hello" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_rest_api.this.root_resource_id
+  path_part   = "hello"
+}
+
+# Método GET para /hello
+resource "aws_api_gateway_method" "get_hello" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.hello.id
+  http_method   = "GET"
+  authorization = "COGNITO_USER_POOLS"
+  authorizer_id = aws_api_gateway_authorizer.cognito.id
+}
+
+
+resource "aws_api_gateway_integration" "get_hello_integration" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  resource_id = aws_api_gateway_resource.hello.id
+  http_method = aws_api_gateway_method.get_hello.http_method
+  
+  integration_http_method = "POST"  
+  type                    = "AWS_PROXY"
+  uri                     = var.lambda_invoke_arn
+}
+
+# Adiciona método response
+resource "aws_api_gateway_method_response" "get_hello_response_200" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  resource_id = aws_api_gateway_resource.hello.id
+  http_method = aws_api_gateway_method.get_hello.http_method
+  status_code = "200"
+
+  response_models = {
+    "application/json" = "Empty"
+  }
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Origin" = false
+  }
+}
+
+#  Adiciona integration response
+resource "aws_api_gateway_integration_response" "get_hello_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  resource_id = aws_api_gateway_resource.hello.id
+  http_method = aws_api_gateway_method.get_hello.http_method
+  status_code = aws_api_gateway_method_response.get_hello_response_200.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Origin" = "'*'"
+  }
+
+  depends_on = [aws_api_gateway_integration.get_hello_integration]
+}
+
+# Permissão Lambda específica
+resource "aws_lambda_permission" "api_gateway_lambda" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  
+  # Mais específico para o método GET em /hello
+  source_arn = "${aws_api_gateway_rest_api.this.execution_arn}/*/GET/hello"
+}
+
+# Authorizer Cognito
+resource "aws_api_gateway_authorizer" "cognito" {
+  name                   = "${var.api_name}-cognito-authorizer"
+  rest_api_id           = aws_api_gateway_rest_api.this.id
+  type                  = "COGNITO_USER_POOLS"
+  provider_arns         = [var.cognito_user_pool_arn]
+  identity_source       = "method.request.header.Authorization"
+}
+
+# Deploy do API Gateway
+resource "aws_api_gateway_deployment" "this" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+
+  depends_on = [
+    aws_api_gateway_method.get_hello,
+    aws_api_gateway_integration.get_hello_integration,
+    aws_api_gateway_method_response.get_hello_response_200,
+    aws_api_gateway_integration_response.get_hello_integration_response
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  
+  
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_resource.hello.id,
+      aws_api_gateway_method.get_hello.id,
+      aws_api_gateway_integration.get_hello_integration.id,
+    ]))
+  }
+}
+
+# Stage do API Gateway
+resource "aws_api_gateway_stage" "this" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  deployment_id = aws_api_gateway_deployment.this.id
+  stage_name    = var.environment
+  
+  # Habilita logs para debug
+  xray_tracing_enabled = true
+  
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_gateway.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip            = "$context.identity.sourceIp"
+      caller        = "$context.identity.caller"
+      user          = "$context.identity.user"
+      requestTime   = "$context.requestTime"
+      httpMethod    = "$context.httpMethod"
+      resourcePath  = "$context.resourcePath"
+      status        = "$context.status"
+      protocol      = "$context.protocol"
+      responseLength = "$context.responseLength"
+      error         = "$context.error.message"
+      integrationError = "$context.integrationErrorMessage"
+    })
+  }
+}
+
+# CloudWatch Log Group para API Gateway
+resource "aws_cloudwatch_log_group" "api_gateway" {
+  name              = "/aws/apigateway/${var.api_name}"
+  retention_in_days = 7
+}
+
+#  Configurar API Gateway Account 
+resource "aws_api_gateway_account" "this" {
+  cloudwatch_role_arn = var.api_gateway_cloudwatch_role_arn
+}

--- a/terraform/modules/api_gateway/outputs.tf
+++ b/terraform/modules/api_gateway/outputs.tf
@@ -1,0 +1,9 @@
+output "api_endpoint" {
+  description = "URL do endpoint do API Gateway"
+  value       = "${aws_api_gateway_stage.this.invoke_url}/${aws_api_gateway_resource.hello.path_part}"
+}
+
+output "api_id" {
+  description = "ID do API Gateway"
+  value       = aws_api_gateway_rest_api.this.id
+}

--- a/terraform/modules/api_gateway/variables.tf
+++ b/terraform/modules/api_gateway/variables.tf
@@ -1,0 +1,30 @@
+variable "api_name" {
+  description = "Nome do API Gateway"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de deploy"
+  type        = string
+}
+
+variable "cognito_user_pool_arn" {
+  description = "ARN do Cognito User Pool"
+  type        = string
+}
+
+variable "lambda_invoke_arn" {
+  description = "ARN para invocação da função Lambda"
+  type        = string
+}
+
+variable "lambda_function_name" {
+  description = "Nome da função Lambda"
+  type        = string
+}
+
+
+variable "api_gateway_cloudwatch_role_arn" {
+  description = "ARN do IAM Role para CloudWatch logs do API Gateway"
+  type        = string
+}

--- a/terraform/modules/cognito/outputs.tf
+++ b/terraform/modules/cognito/outputs.tf
@@ -10,4 +10,9 @@ output "cognito_domain" {
   value = "https://${aws_cognito_user_pool_domain.this.domain}.auth.${data.aws_region.current.name}.amazoncognito.com"
 }
 
+output "user_pool_arn" {
+  description = "ARN do Cognito User Pool"
+  value       = aws_cognito_user_pool.this.arn
+}
+
 data "aws_region" "current" {}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -22,3 +22,8 @@ output "delete_item_lambda_arn" {
   description = "ARN da função Lambda Delete Item"
   value       = module.delete_item.function_arn
 }
+
+output "api_gateway_endpoint" {
+  description = "Endpoint do API Gateway para /hello"
+  value       = module.api_gateway.api_endpoint
+}

--- a/terraform/temp/src/lambdas/hello_terraform/lambda_function.py
+++ b/terraform/temp/src/lambdas/hello_terraform/lambda_function.py
@@ -1,0 +1,18 @@
+"""
+Função Lambda que retorna uma mensagem 'Hello Terraform'.
+
+Esta função é um exemplo simples que retorna um objeto JSON
+com status code 200 e a mensagem "Hello Terraform".
+"""
+import json
+
+def lambda_handler(event, context):
+    """
+    Manipulador da função Lambda.
+
+    :param event: Evento que acionou a função
+    :param context: Contexto de execução da Lambda
+    :return: Resposta com status 200 e mensagem "Hello Terraform"
+    """
+    body = {"message": "Hello Terraform"}
+    return {"statusCode": 200, "body": json.dumps(body)}


### PR DESCRIPTION
Implementação de API Gateway integrado com Cognito para proteger o endpoint /hello com autenticação JWT.
Alterações Realizadas

Criação de API Gateway REST API
Configuração de Authorizer Cognito vinculado ao User Pool existente
Implementação do método GET /hello com autorização obrigatória
Integração com Lambda function hello (já existente via Terraform)

Funcionalidades
✅ Endpoint protegido: GET /hello
✅ Autenticação via token JWT do Cognito
✅ Integração com Lambda backend
✅ Validação de autorização obrigatória

Testes Realizados

Teste via Postman com token JWT válido: 200 OK
Validação de autorização funcionando corretamente
Integração Lambda operacional

Endpoints
GET /hello
Authorization: Bearer {cognito-jwt-token}


Testes: ✅ Validados via Postman


![teste_postman](https://github.com/user-attachments/assets/24712b73-b180-46f8-85fe-9d608a9b01b2)
![caminho_hello](https://github.com/user-attachments/assets/fc347619-438f-4eb0-bbd6-70109441a905)
